### PR TITLE
Adds package.json license

### DIFF
--- a/template/$PROJECT_NAME$/assets/package.json
+++ b/template/$PROJECT_NAME$/assets/package.json
@@ -1,5 +1,4 @@
 {
-  "repository": {},
   "dependencies": {
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html"
@@ -22,6 +21,9 @@
     "webpack": "^2.4.1",
     "phantomjs-prebuilt": "^2.1.7"
   },
+  "license": "UNLICENSED",
+  "private": true,
+  "repository": {},
   "scripts": {
     "test": "standard && ./node_modules/webpack/bin/webpack.js",
     "compile": "webpack -p"


### PR DESCRIPTION
This PR fixes #12 by updating `assets/package.json`.

This PR adds a `license` and `private` node to the `package.json`. The `license` node will remove the `warning` when running `yarn run webpack` and `private: true` keeps a developer from accidentally publishing a public npm package. 

See https://docs.npmjs.com/files/package.json#license for further details.